### PR TITLE
Ignore HTTP errors by default (can be overridden by user)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ To checkout the current master (development) branch:
 ```julia
 Pkg.checkout("BioMedQuery")
 ```
+

--- a/test/processes_mysql.jl
+++ b/test/processes_mysql.jl
@@ -49,12 +49,12 @@ PubMed.create_tables!(conn)
 
 end
 
-@testset "MESH2UMLS" begin
-    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
-    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
-    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
-    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
+# If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+# If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+# If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+is_not_travis_pull_request = get(ENV, "TRAVIS_PULL_REQUEST", "false") == "false"
 
+@testset "MESH2UMLS" begin
     if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing MESH2UMLS")
@@ -101,11 +101,6 @@ end
 end
 
 @testset "Occurrences" begin
-    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
-    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
-    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
-    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
-
     if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing Occurrences")

--- a/test/processes_mysql.jl
+++ b/test/processes_mysql.jl
@@ -63,15 +63,15 @@ end
         println("       Testing MESH2UMLS")
         append = false
 
-        success = try
+        success = true
+        try
             @time begin
                 map_mesh_to_umls_async!(conn, umls_user, umls_pswd; append_results=append, timeout=1)
             end
-            true
         catch e
             if isa(e, HTTP.ExceptionRequest.StatusError)
                 warn(string("ignoring error: "), e)
-                false
+                success = false
             else
                 rethrow(e)
             end
@@ -82,15 +82,15 @@ end
             @test length(all_pairs) > 0
         end
 
-        success = try
+        success = true
+        try
             @time begin
                 map_mesh_to_umls!(conn, umls_user, umls_pswd; append_results=append, timeout=1)
             end
-            true
         catch e
             if isa(e, HTTP.ExceptionRequest.StatusError)
                 warn(string("ignoring error: "), e)
-                false
+                success = false
             else
                 rethrow(e)
             end
@@ -116,16 +116,16 @@ end
         println("-----------------------------------------")
         println("       Testing Occurrences")
         umls_concept = "Disease or Syndrome"
-        
-        success = try
+
+        success = true
+        try
             @time begin
                 labels2ind, occur = umls_semantic_occurrences(conn, umls_concept)
             end
-            true
         catch e
             if isa(e, HTTP.ExceptionRequest.StatusError)
                 warn(string("ignoring error: "), e)
-                false
+                success = false
             else
                 rethrow(e)
             end

--- a/test/processes_mysql.jl
+++ b/test/processes_mysql.jl
@@ -50,15 +50,12 @@ PubMed.create_tables!(conn)
 end
 
 @testset "MESH2UMLS" begin
-    # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
-    is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
 
-    # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
-    is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
-
-    # If this is a Travis build, only execute this test if it is NOT a pull request.
-    # If this is not a Travis build, then always execute this test.
-    if !is_travis || !is_travis_pull_request
+    if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing MESH2UMLS")
         append = false
@@ -104,15 +101,12 @@ end
 end
 
 @testset "Occurrences" begin
-    # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
-    is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
 
-    # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
-    is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
-
-    # If this is a Travis build, only execute this test if it is NOT a pull request.
-    # If this is not a Travis build, then always execute this test.
-    if !is_travis || !is_travis_pull_request
+    if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing Occurrences")
         umls_concept = "Disease or Syndrome"

--- a/test/processes_mysql.jl
+++ b/test/processes_mysql.jl
@@ -50,66 +50,89 @@ PubMed.create_tables!(conn)
 end
 
 @testset "MESH2UMLS" begin
-    ignore_http_errors = lowercase(strip(get(ENV, "IGNORE_HTTP_ERRORS", "true"))) == "true"
-
     # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
     is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+
     # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
     is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
+
     # If this is a Travis build, only execute this test if it is NOT a pull request.
     # If this is not a Travis build, then always execute this test.
     if !is_travis || !is_travis_pull_request
-        try
-            println("-----------------------------------------")
-            println("       Testing MESH2UMLS")
-            append = false
+        println("-----------------------------------------")
+        println("       Testing MESH2UMLS")
+        append = false
+
+        success = try
             @time begin
                 map_mesh_to_umls_async!(conn, umls_user, umls_pswd; append_results=append, timeout=1)
             end
-            all_pairs_query = db_query(conn, "SELECT mesh FROM mesh2umls;")
-            all_pairs = all_pairs_query[1]
-            @test length(all_pairs) > 0
-            @time begin
-                map_mesh_to_umls!(conn, umls_user, umls_pswd; append_results=append, timeout=1)
-            end
-            all_pairs_query = db_query(conn, "SELECT mesh FROM mesh2umls;")
-            all_pairs = all_pairs_query[1]
-            @test length(all_pairs) > 0
+            true
         catch e
-            if typeof(e) <: HTTP.ExceptionRequest.StatusError && ignore_http_errors
-                warn(string("Ignoring error: ", e,))
+            if isa(e, HTTP.ExceptionRequest.StatusError)
+                warn(string("ignoring error: "), e)
+                false
             else
                 rethrow(e)
             end
+        end
+        if success
+            all_pairs_query = db_query(conn, "SELECT mesh FROM mesh2umls;")
+            all_pairs = all_pairs_query[1]
+            @test length(all_pairs) > 0
+        end
+
+        success = try
+            @time begin
+                map_mesh_to_umls!(conn, umls_user, umls_pswd; append_results=append, timeout=1)
+            end
+            true
+        catch e
+            if isa(e, HTTP.ExceptionRequest.StatusError)
+                warn(string("ignoring error: "), e)
+                false
+            else
+                rethrow(e)
+            end
+        end
+        if success
+            all_pairs_query = db_query(conn, "SELECT mesh FROM mesh2umls;")
+            all_pairs = all_pairs_query[1]
+            @test length(all_pairs) > 0
         end
     end
 end
 
 @testset "Occurrences" begin
-    ignore_http_errors = lowercase(strip(get(ENV, "IGNORE_HTTP_ERRORS", "true"))) == "true"
-
     # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
     is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+
     # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
     is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
+
     # If this is a Travis build, only execute this test if it is NOT a pull request.
     # If this is not a Travis build, then always execute this test.
     if !is_travis || !is_travis_pull_request
-        try
-            println("-----------------------------------------")
-            println("       Testing Occurrences")
-            umls_concept = "Disease or Syndrome"
+        println("-----------------------------------------")
+        println("       Testing Occurrences")
+        umls_concept = "Disease or Syndrome"
+        
+        success = try
             @time begin
                 labels2ind, occur = umls_semantic_occurrences(conn, umls_concept)
             end
-            @test length(keys(labels2ind)) > 0
-            @test length(find(x->x=="Obesity", collect(keys(labels2ind)))) ==1
+            true
         catch e
-            if typeof(e) <: HTTP.ExceptionRequest.StatusError && ignore_http_errors
-                warn(string("Ignoring error: ", e,))
+            if isa(e, HTTP.ExceptionRequest.StatusError)
+                warn(string("ignoring error: "), e)
+                false
             else
                 rethrow(e)
             end
+        end
+        if success
+            @test length(keys(labels2ind)) > 0
+            @test length(find(x->x=="Obesity", collect(keys(labels2ind)))) ==1
         end
     end
 end

--- a/test/processes_sqlite.jl
+++ b/test/processes_sqlite.jl
@@ -31,15 +31,12 @@ PubMed.create_tables!(conn_sql)
 end
 
 @testset "MESH2UMLS" begin
-    # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
-    is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
 
-    # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
-    is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
-
-    # If this is a Travis build, only execute this test if it is NOT a pull request.
-    # If this is not a Travis build, then always execute this test.
-    if !is_travis || !is_travis_pull_request
+    if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing MESH2UMLS")
         umls_user = get(ENV, "UMLS_USER", "")
@@ -87,13 +84,12 @@ end
 end
 
 @testset "Occurrences" begin
-    # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
-    is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
+    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
 
-    # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
-    is_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", ""))) != "false"
-
-    if !is_travis || !is_travis_pull_request
+    if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing Occurrences")
         umls_concept = "Disease or Syndrome"

--- a/test/processes_sqlite.jl
+++ b/test/processes_sqlite.jl
@@ -46,15 +46,15 @@ end
         umls_pswd = get(ENV, "UMLS_PSSWD", "")
         append = false
 
-        success = try
+        success = true
+        try
             @time begin
                 map_mesh_to_umls_async!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
             end
-            true
         catch e
             if isa(e, HTTP.ExceptionRequest.StatusError)
                 warn(string("ignoring error: "), e)
-                false
+                success = false
             else
                 rethrow(e)
             end
@@ -65,15 +65,15 @@ end
             @test length(all_pairs) > 0
         end
 
-        success = try
+        success = true
+        try
             @time begin
                 map_mesh_to_umls!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
             end
-            true
         catch e
             if isa(e, HTTP.ExceptionRequest.StatusError)
                 warn(string("ignoring error: "), e)
-                false
+                success = false
             else
                 rethrow(e)
             end
@@ -97,13 +97,19 @@ end
         println("-----------------------------------------")
         println("       Testing Occurrences")
         umls_concept = "Disease or Syndrome"
-        
-        success = try
+
+        success = true
+        try
             @time begin
                 labels2ind, occur = umls_semantic_occurrences(conn_sql, umls_concept)
             end
-            true
         catch e
+            if isa(e, HTTP.ExceptionRequest.StatusError)
+                warn(string("ignoring error: "), e)
+                success = false
+            else
+                rethrow(e)
+            end
         end
         if success
             @test length(keys(labels2ind)) > 0

--- a/test/processes_sqlite.jl
+++ b/test/processes_sqlite.jl
@@ -1,3 +1,5 @@
+import HTTP
+
 #************************ LOCALS TO CONFIGURE!!!! **************************
 const email= "" #This is an enviroment variable that you need to setup
 const search_term="(obesity[MeSH Major Topic]) AND (\"2010\"[Date - Publication] : \"2012\"[Date - Publication])"
@@ -29,6 +31,8 @@ PubMed.create_tables!(conn_sql)
 end
 
 @testset "MESH2UMLS" begin
+    ignore_http_errors = lowercase(strip(get(ENV, "IGNORE_HTTP_ERRORS", "true"))) == "true"
+
     # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
     is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
     # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
@@ -36,27 +40,37 @@ end
     # If this is a Travis build, only execute this test if it is NOT a pull request.
     # If this is not a Travis build, then always execute this test.
     if !is_travis || !is_travis_pull_request
-        println("-----------------------------------------")
-        println("       Testing MESH2UMLS")
-        umls_user = get(ENV, "UMLS_USER", "")
-        umls_pswd = get(ENV, "UMLS_PSSWD", "")
-        append = false
-        @time begin
-            map_mesh_to_umls_async!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
+        try
+            println("-----------------------------------------")
+            println("       Testing MESH2UMLS")
+            umls_user = get(ENV, "UMLS_USER", "")
+            umls_pswd = get(ENV, "UMLS_PSSWD", "")
+            append = false
+            @time begin
+                map_mesh_to_umls_async!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
+            end
+            all_pairs_query = db_query(conn_sql, "SELECT mesh FROM mesh2umls;")
+            all_pairs = all_pairs_query[1]
+            @test length(all_pairs) > 0
+            @time begin
+                map_mesh_to_umls!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
+            end
+            all_pairs_query = db_query(conn_sql, "SELECT mesh FROM mesh2umls;")
+            all_pairs = all_pairs_query[1]
+            @test length(all_pairs) > 0
+        catch e
+            if typeof(e) <: HTTP.ExceptionRequest.StatusError && ignore_http_errors
+                warn(string("Ignoring error: ", e,))
+            else
+                rethrow(e)
+            end
         end
-        all_pairs_query = db_query(conn_sql, "SELECT mesh FROM mesh2umls;")
-        all_pairs = all_pairs_query[1]
-        @test length(all_pairs) > 0
-        @time begin
-            map_mesh_to_umls!(conn_sql, umls_user, umls_pswd; append_results=append, timeout=1)
-        end
-        all_pairs_query = db_query(conn_sql, "SELECT mesh FROM mesh2umls;")
-        all_pairs = all_pairs_query[1]
-        @test length(all_pairs) > 0
     end
 end
 
 @testset "Occurrences" begin
+    ignore_http_errors = lowercase(strip(get(ENV, "IGNORE_HTTP_ERRORS", "true"))) == "true"
+
     # $TRAVIS is equal to "true" if it's a Travis build, and "false" if it's not.
     is_travis = lowercase(strip(get(ENV, "TRAVIS", ""))) == "true"
     # $TRAVIS_PULL_REQUEST is equal to the PR number if it is a PR, and "false" if it's not.
@@ -64,14 +78,22 @@ end
     # If this is a Travis build, only execute this test if it is NOT a pull request.
     # If this is not a Travis build, then always execute this test.
     if !is_travis || !is_travis_pull_request
-        println("-----------------------------------------")
-        println("       Testing Occurrences")
-        umls_concept = "Disease or Syndrome"
-        @time begin
-            labels2ind, occur = umls_semantic_occurrences(conn_sql, umls_concept)
+        try
+            println("-----------------------------------------")
+            println("       Testing Occurrences")
+            umls_concept = "Disease or Syndrome"
+            @time begin
+                labels2ind, occur = umls_semantic_occurrences(conn_sql, umls_concept)
+            end
+            @test length(keys(labels2ind)) > 0
+            @test length(find(x->x=="Obesity", collect(keys(labels2ind)))) ==1
+        catch e
+            if typeof(e) <: HTTP.ExceptionRequest.StatusError && ignore_http_errors
+                warn(string("Ignoring error: ", e,))
+            else
+                rethrow(e)
+            end
         end
-        @test length(keys(labels2ind)) > 0
-        @test length(find(x->x=="Obesity", collect(keys(labels2ind)))) ==1
     end
 end
 

--- a/test/processes_sqlite.jl
+++ b/test/processes_sqlite.jl
@@ -30,12 +30,12 @@ PubMed.create_tables!(conn_sql)
 
 end
 
-@testset "MESH2UMLS" begin
-    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
-    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
-    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
-    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
+# If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
+# If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
+# If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
+is_not_travis_pull_request = get(ENV, "TRAVIS_PULL_REQUEST", "false") == "false"
 
+@testset "MESH2UMLS" begin
     if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing MESH2UMLS")
@@ -84,11 +84,6 @@ end
 end
 
 @testset "Occurrences" begin
-    # If this is a Travis build and is a PR, then $TRAVIS_PULL_REQUEST is equal to the PR number.
-    # If this is a Travis build and is not a PR, then $TRAVIS_PULL_REQUEST is equal to "false".
-    # If this is not a Travis build, then $TRAVIS_PULL_REQUEST is unset.
-    is_not_travis_pull_request = lowercase(strip(get(ENV, "TRAVIS_PULL_REQUEST", "false"))) == "false"
-
     if is_not_travis_pull_request
         println("-----------------------------------------")
         println("       Testing Occurrences")


### PR DESCRIPTION
This PR adds code to ignore HTTP errors during the "Occurences" test sets - see issue #24.

If a user wants to override this setting (i.e. they want an HTTP error to result in a test failure), they can do so by setting:
```julia
ENV["IGNORE_HTTP_ERRORS"] = "false"
```

before they run `Pkg.test("BioMedQuery")`.