### PR TITLE
Mkdocs literate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
                 println("Unknown test command.")
           end'
 after_success:
-  - julia -e 'cd(Pkg.dir("BioMedQuery")); Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
+  - julia -e 'cd(Pkg.dir("BioMedQuery")); Pkg.add("Documenter"); Pkg.add("Literate"); include(joinpath("docs", "make.jl"))'
   - julia -e 'cd(Pkg.dir("BioMedQuery")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-BioServices 0.1.1
+BioServices 0.1.2
 CSV
 DataFrames
 DataStreams

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,12 @@
 using Documenter, BioMedQuery
+using Literate
+
+# compile all examples in BioMedQuery/examples/literate_src into markdown for docs using Literate
+for (root, dirs, files) in walkdir("../examples/literate_src")
+    for file in files
+        Literate.markdown(joinpath(root,file), joinpath(@__DIR__, "src", "examples"))
+    end
+end
 
 makedocs()
 

--- a/test/processes_mysql.jl
+++ b/test/processes_mysql.jl
@@ -107,6 +107,8 @@ end
         umls_concept = "Disease or Syndrome"
 
         success = true
+        labels2ind = ""
+        occur = ""
         try
             @time begin
                 labels2ind, occur = umls_semantic_occurrences(conn, umls_concept)

--- a/test/processes_sqlite.jl
+++ b/test/processes_sqlite.jl
@@ -90,6 +90,8 @@ end
         umls_concept = "Disease or Syndrome"
 
         success = true
+        labels2ind = ""
+        occur = ""
         try
             @time begin
                 labels2ind, occur = umls_semantic_occurrences(conn_sql, umls_concept)


### PR DESCRIPTION
Added loop to re-build example markdown for docs at time of documentation build.

UMLS occurrence tests were failing/erroring as try/catch blocks create local scope - the variables set in the try blocks are now initialized before the block starts.

Requires latest version of BioServices.