### PR TITLE
Add DO NOT MERGE label

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,5 @@
+block_labels = [ "DO NOT MERGE" ]
+
 delete_merged_branches = true
 
 status = [


### PR DESCRIPTION
This pull request adds the `DO NOT MERGE` label to the `block_labels` list in `bors.toml`.

If a pull request has the label `DO NOT MERGE` and a user comments `bors r+` on it, Bors will refuse to merge the pull request.

Thus, by adding the `DO NOT MERGE` label to a pull request, we can prevent accidentally merging "work in progress" pull requests and other pull requests that are not ready to be merged.