### PR TITLE
Reorganize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 [![DOI](https://zenodo.org/badge/59500020.svg)](https://zenodo.org/badge/latestdoi/59500020)
 ![Lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg?style=flat-square)
 
+<a href="https://app.bors.tech/repositories/12275"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
+
+BioMedQuery is tested against Julia `0.7` and current `1.X` on
+Linux, and OS X.
+
+| Latest CI Build |
+|:-----------:|
+| [![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Test&label=tests)](https://travis-ci.org/bcbi/BioMedQuery.jl)[![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Examples&label=examples)](https://travis-ci.org/bcbi/BioMedQuery.jl) [![codecov](https://codecov.io/gh/bcbi/BioMedQuery.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bcbi/BioMedQuery.jl)|
+
+
 ## Documentation
 
 | Stable | Latest |  Examples |
@@ -50,13 +60,3 @@ To checkout the latest **development** version:
 using Pkg
 Pkg.dev("BioMedQuery")
 ```
-
-## Testing
-
-BioMedQuery is tested against Julia `0.7` and current `1.X` on
-Linux, and OS X.
-
-
-| Latest CI Build |
-|:-----------:|
-| [![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Test&label=tests)](https://travis-ci.org/bcbi/BioMedQuery.jl)[![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Examples&label=examples)](https://travis-ci.org/bcbi/BioMedQuery.jl) [![codecov](https://codecov.io/gh/bcbi/BioMedQuery.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bcbi/BioMedQuery.jl)|

--- a/README.md
+++ b/README.md
@@ -2,17 +2,14 @@
 
 [![Latest Release](https://img.shields.io/github/release/bcbi/BioMedQuery.jl.svg?style=flat-square)](https://github.com/bcbi/BioMedQuery.jl/releases/latest)
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](https://github.com/bcbi/BioMedQuery.jl/blob/master/LICENSE)
-[![DOI](https://zenodo.org/badge/59500020.svg)](https://zenodo.org/badge/latestdoi/59500020)
 ![Lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg?style=flat-square)
+![Bors Enabled](https://bors.tech/images/badge_small.svg)
 
-<a href="https://app.bors.tech/repositories/12275"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
-
-BioMedQuery is tested against Julia `0.7` and current `1.X` on
-Linux, and OS X.
+BioMedQuery is tested against Julia `1.X` on Linux, and OS X.
 
 | Latest CI Build |
 |:-----------:|
-| [![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Test&label=tests)](https://travis-ci.org/bcbi/BioMedQuery.jl)[![](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&env=GROUP=Examples&label=examples)](https://travis-ci.org/bcbi/BioMedQuery.jl) [![codecov](https://codecov.io/gh/bcbi/BioMedQuery.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bcbi/BioMedQuery.jl)|
+| [![Tests](https://badges.herokuapp.com/travis/bcbi/BioMedQuery.jl?branch=master&label=tests)](https://travis-ci.org/bcbi/BioMedQuery.jl) [![Code Coverage](https://codecov.io/gh/bcbi/BioMedQuery.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bcbi/BioMedQuery.jl)|
 
 
 ## Documentation


### PR DESCRIPTION
It is very strange that some of the badges are located at the top of the readme, but then the Travis and code coverage badges are located at the bottom of the README.  I’d rather keep all of the status badges together in one place at the top of the readme.

@ibacher Take a look at this, edit it to make it look nice and readable, and then merge whenever you are happy with the final product.